### PR TITLE
feat: Add PubMed Central download capability (re-integration)

### DIFF
--- a/scihub_downloader.py
+++ b/scihub_downloader.py
@@ -11,6 +11,7 @@ import sys
 from datetime import datetime
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin
+import json
 
 # --- Configuration Constants (Primarily for defaults now) ---
 DEFAULT_SCI_HUB_MIRRORS_EXAMPLE = [ 
@@ -255,105 +256,100 @@ def download_from_google_scholar(doi, title, session):
         return None, "FALLO - Unexpected error with Google Scholar"
 
 def download_from_pmc(doi, title, session):
-    """
-    Tries to download a PDF from PubMed Central (PMC) using DOI.
-    """
-    # 1. Convert DOI to PMCID
-    pmcid = None
+    # print(f"Attempting PubMed Central download for DOI: {doi}") # Keep internal prints commented for now
     try:
-        id_conv_url = f"https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/?ids={doi}&format=json&tool=scihub_downloader_script&email=user@example.com"
-        response = session.get(id_conv_url, timeout=20)
-        response.raise_for_status()
-        data = response.json()
-        if data.get("status") == "ok" and data.get("records"):
-            for record in data["records"]:
-                if record.get("doi") == doi and record.get("pmcid"):
-                    pmcid = record["pmcid"]
-                    break
+        # Step 1: Convert DOI to PMCID
+        id_conv_url = f"https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/?ids={doi}&format=json&tool=my_tool&email=my_email@example.com"
+        # print(f"PMC ID Converter URL: {id_conv_url}")
+        try:
+            response = session.get(id_conv_url, timeout=20)
+            response.raise_for_status()
+            data = response.json()
+        except requests.exceptions.RequestException as e:
+            # print(f"PMC ID Conv API request failed: {e}")
+            return None, f"FALLO - Error API conversión PMCID ({str(e)[:50]})"
+        except json.JSONDecodeError:
+            # print(f"PMC ID Conv API JSON decode error. Response text: {response.text[:200]}")
+            return None, "FALLO - Error decodificando respuesta PMCID"
+
+        pmcid = None
+        if data.get("records") and len(data["records"]) > 0:
+            if "pmcid" in data["records"][0]:
+                pmcid = data["records"][0]["pmcid"]
+            # else:
+                # print(f"PMCID not found in record: {data['records'][0]}")
+        # else:
+            # print(f"No records found in PMC ID Conv API response: {data}")
+
         if not pmcid:
-            return None, "FALLO - PMCID no encontrado para DOI"
-    except requests.exceptions.RequestException as e:
-        # print(f"PMC ID conversion API request error for DOI {doi}: {e}")
-        return None, "FALLO - Error en API de conversión PMCID"
-    except Exception as e: # Includes JSONDecodeError
-        # print(f"PMC ID conversion parsing error for DOI {doi}: {e}")
-        return None, "FALLO - Error procesando respuesta de API PMCID"
+            return None, f"FALLO - PMCID no encontrado para DOI {doi}"
 
-    # 2. Access PMC Article and Find PDF
-    if not pmcid: # Should have returned already, but as a safeguard
-        return None, "FALLO - PMCID no encontrado (safeguard)"
+        # print(f"Found PMCID: {pmcid}")
 
-    try:
-        pmc_article_url = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/"
-        headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'}
-        article_response = session.get(pmc_article_url, headers=headers, timeout=30)
-        article_response.raise_for_status()
-        soup = BeautifulSoup(article_response.content, 'html.parser')
+        # Step 2: Access PMC Article and Find PDF
+        article_url = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/"
+        # print(f"PMC Article URL: {article_url}")
+        try:
+            response = session.get(article_url, timeout=30)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            # print(f"PMC Article page request failed: {e}")
+            return None, f"FALLO - Error obteniendo página PMC {pmcid} ({str(e)[:50]})"
+
+        soup = BeautifulSoup(response.content, 'html.parser')
 
         pdf_links = []
-        # Common pattern: links in a 'format-menu' div, or specific class like 'pdf-link'
-        format_menu = soup.find('div', class_='format-menu')
-        if format_menu:
-            for a_tag in format_menu.find_all('a', href=True):
-                if '.pdf' in a_tag['href'].lower():
-                    pdf_links.append(a_tag['href'])
+        # Common pattern for PDF links on PMC
+        for link_tag in soup.find_all('a', href=True):
+            href = link_tag['href']
+            # Check for links that explicitly point to a PDF rendition
+            if '/pdf/' in href and href.lower().endswith('.pdf'):
+                pdf_links.append(urljoin(article_url, href))
+            # Check for links in the "Download" or "Formats" sections, often with specific attributes
+            elif link_tag.get('title') == 'Download PDF' or 'pdf' in link_tag.get_text().lower():
+                 if href.lower().endswith('.pdf') or '/pmc/articles/' in href.lower() and 'rendering=' in href.lower(): # Heuristic for render links
+                    pdf_links.append(urljoin(article_url, href))
 
-        # General search for links containing '/pdf/' and the pmcid (more robust)
-        for a_tag in soup.find_all('a', href=True):
-            href = a_tag['href']
-            if pmcid in href and '/pdf/' in href and href.lower().endswith('.pdf'):
-                pdf_links.append(href)
-
-        # Fallback: direct construction if a known pattern for PMC PDF links exists (often includes article base name)
-        # Example: /pmc/articles/PMC1234567/pdf/jnm0101-0001.pdf - the last part is variable
-        # This might require more sophisticated pattern matching if the exact file name isn't easily found in other tags.
-        # For now, we rely on explicit links.
 
         # De-duplicate potential links
         unique_pdf_links = []
-        for link in pdf_links:
-            abs_link = urljoin(pmc_article_url, link) # Ensure absolute
-            if abs_link not in unique_pdf_links:
-                unique_pdf_links.append(abs_link)
+        for plink in pdf_links:
+            if plink not in unique_pdf_links:
+                unique_pdf_links.append(plink)
+
+        # print(f"Found potential PMC PDF links: {unique_pdf_links}")
 
         if not unique_pdf_links:
             return None, f"FALLO - PDF no encontrado en la página PMC para {pmcid}"
 
-        # 3. Download PDF
+        # Step 3: Download PDF
         for pdf_url_to_try in unique_pdf_links:
+            # print(f"Attempting to download PDF from PMC link: {pdf_url_to_try}")
             try:
-                head_response = session.head(pdf_url_to_try, headers=headers, timeout=20, allow_redirects=True)
+                head_response = session.head(pdf_url_to_try, timeout=20, allow_redirects=True)
                 head_response.raise_for_status()
                 content_type = head_response.headers.get('Content-Type', '').lower()
 
                 if 'application/pdf' in content_type:
-                    pdf_response = session.get(pdf_url_to_try, headers=headers, timeout=60, stream=True)
+                    pdf_response = session.get(pdf_url_to_try, timeout=60, stream=True)
                     pdf_response.raise_for_status()
-                    get_content_type = pdf_response.headers.get('Content-Type', '').lower()
+                    get_content_type = pdf_response.headers.get('Content-Type', '').lower() # Check again after GET
                     if 'application/pdf' in get_content_type:
-                        pdf_content = pdf_response.content
-                        return pdf_content, f"OBTENIDO (PubMed Central {pmcid})"
+                        # print(f"Successfully downloaded PDF from {pdf_url_to_try}")
+                        return pdf_response.content, f"OBTENIDO (PubMed Central {pmcid})"
                     # else:
-                        # print(f"PMC GET request for {pdf_url_to_try} did not return PDF content-type, but: {get_content_type}")
+                        # print(f"PMC GET Content-Type not PDF: {get_content_type} from {pdf_url_to_try}")
                 # else:
-                    # print(f"PMC HEAD request for {pdf_url_to_try} did not indicate PDF content-type: {content_type}")
-
-            except requests.exceptions.RequestException as e_dl:
-                # print(f"PMC PDF download error from {pdf_url_to_try}: {e_dl}")
-                continue # Try next link
-            except Exception as e_dl_unex:
-                # print(f"PMC PDF unexpected download error from {pdf_url_to_try}: {e_dl_unex}")
+                    # print(f"PMC HEAD Content-Type not PDF: {content_type} from {pdf_url_to_try}")
+            except requests.exceptions.RequestException as e:
+                # print(f"Failed to download from PMC PDF link {pdf_url_to_try}: {e}")
                 continue # Try next link
 
         return None, f"FALLO - No se pudo descargar PDF desde enlaces PMC para {pmcid}"
 
-    except requests.exceptions.RequestException as e_page:
-        # print(f"PMC article page request error for PMCID {pmcid}: {e_page}")
-        return None, f"FALLO - Error accediendo a página PMC para {pmcid}"
-    except Exception as e_page_parse: # Includes BeautifulSoup errors
-        # print(f"PMC article page parsing error for PMCID {pmcid}: {e_page_parse}")
-        return None, f"FALLO - Error procesando página PMC para {pmcid}"
-
+    except Exception as e:
+        # print(f"Unexpected error in download_from_pmc for DOI {doi}: {e}")
+        return None, f"FALLO - Error inesperado en PubMed Central ({str(e)[:50]})"
 
 def print_to_console(message, orig_stdout):
     print(message, file=orig_stdout)
@@ -604,7 +600,7 @@ def download_pdfs_from_file():
                             # PDF not found with this mirror, temp_failure_reason_for_log has the specific reason
                             if mirror_idx < len(mirrors_to_try_for_this_doi) - 1:
                                 time.sleep(user_mirror_switch_delay)
-                    
+
                     # After Sci-Hub loop, if still no pdf_content, try Google Scholar
                     if not pdf_content:
                         # print(f"Sci-Hub attempts failed for DOI {doi}. Trying Google Scholar.") # Debug print commented out
@@ -625,22 +621,22 @@ def download_pdfs_from_file():
                             temp_failure_reason_for_log = gs_status_msg
                             temp_detailed_status_for_log = f"Failure_GoogleScholar_{gs_status_msg}"
 
-                    # If Sci-Hub and Google Scholar attempts failed, try PubMed Central
+                    # After Google Scholar attempt, if still no pdf_content, try PubMed Central
                     if not pdf_content:
-                        # print(f"Sci-Hub & Google Scholar attempts failed for DOI {doi}. Trying PubMed Central.") # Debug print
+                        # Optional: print(f"Sci-Hub and Google Scholar failed for {doi}. Trying PubMed Central.")
                         pmc_pdf_content, pmc_status_msg = download_from_pmc(doi, effective_title, session)
                         if pmc_pdf_content:
                             pdf_content = pmc_pdf_content
                             download_successful_this_doi = True
-                            successful_mirror_for_this_doi = "PubMed Central"
+                            successful_mirror_for_this_doi = pmc_status_msg # e.g., "OBTENIDO (PubMed Central PMCID_HERE)"
                             overall_doi_status = pmc_status_msg
                             mirror_attempts_details_for_doi.append(("PubMed Central", "OBTENIDO", pmc_status_msg))
-                            temp_detailed_status_for_log = f"Success_PMC_{pmc_status_msg}"
-                            temp_failure_reason_for_log = "" # Clear overall DOI failure as PMC succeeded
+                            temp_detailed_status_for_log = f"Success_PubMedCentral_{pmc_status_msg}"
+                            temp_failure_reason_for_log = "" # Clear failure reason as PMC succeeded
                         else:
                             mirror_attempts_details_for_doi.append(("PubMed Central", "FALLO", pmc_status_msg))
-                            temp_failure_reason_for_log = pmc_status_msg # Update with PMC failure status
-                            temp_detailed_status_for_log = f"Failure_PMC_{pmc_status_msg}"
+                            temp_failure_reason_for_log = pmc_status_msg # Update with PMC failure reason
+                            temp_detailed_status_for_log = f"Failure_PubMedCentral_{pmc_status_msg}"
 
                     end_time = datetime.now()
                     if download_successful_this_doi and pdf_content:
@@ -831,7 +827,7 @@ def download_pdfs_from_file():
                     else:
                         mirror_attempts_details_for_retry.append(("PubMed Central (Retry)", "FALLO", pmc_status_msg_retry))
                         temp_failure_reason_for_retry_log = pmc_status_msg_retry
-                        temp_detailed_status_for_retry_log = f"Failure_RETRY_PMC_{pmc_status_msg_retry}"
+                        temp_detailed_status_for_retry_log = f"Failure_RETRY_PubMedCentral_{pmc_status_msg_retry}"
 
                 retry_end_time_actual_attempt = datetime.now()
                 original_article_log_entry = next((log for log in all_articles_log if str(log.get('DOI', log.get('doi', ''))).strip() == doi_to_retry), None)


### PR DESCRIPTION
Re-adds PubMed Central (PMC) as a PDF download source, implemented on your provided stable codebase.

Key changes:
- Defined the `download_from_pmc(doi, title, session)` function:
    - Converts DOI to PMCID via NCBI API.
    - Fetches and parses PMC article page for PDF links.
    - Downloads PDF if found, with minimal internal printing.
- Integrated `download_from_pmc` into `download_pdfs_from_file` (main and retry loops) as a fallback after Sci-Hub and Google Scholar attempts fail.
- Ensured relevant status, logging, and Excel reporting variables are updated to reflect PMC download attempts and outcomes.